### PR TITLE
(#71) Refactor missing params calculation warning

### DIFF
--- a/src/app/types/types.ts
+++ b/src/app/types/types.ts
@@ -74,6 +74,13 @@ export type ZoneFigma = Omit<Zone, "createdFrom"> & {
   elementId: string;
   hidden?: boolean;
 };
+
+export type ZoneMissingParams= {
+  zoneId: string;
+  zoneName: string;
+  zoneType: ZoneType | "undefined";
+  zoneMissingParams: string[];
+}
 export type TreeZoneEl = {
   id: string;
   children?: TreeZoneEl[];

--- a/src/assets/Fleche_Fermee.svg
+++ b/src/assets/Fleche_Fermee.svg
@@ -1,3 +1,3 @@
 <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M1 11L6 6L1 1" stroke="black"/>
+<path d="M1 11L6 6L1 1"/>
 </svg>

--- a/src/assets/Fleche_Ouvert.svg
+++ b/src/assets/Fleche_Ouvert.svg
@@ -1,3 +1,3 @@
 <svg width="12" height="7" viewBox="0 0 12 7" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M1 1L6 6L11 1" stroke="black"/>
+<path d="M1 1L6 6L11 1"/>
 </svg>

--- a/src/components/layout/AccordionChevron.tsx
+++ b/src/components/layout/AccordionChevron.tsx
@@ -3,11 +3,13 @@ import { css, cx } from "@emotion/css";
 import { ReactComponent as OpenIcon } from "../../assets/Fleche_Fermee.svg";
 interface AccordionChevronProps {
   isExpanded: boolean;
+  isWarning?: true;
   setOpen?: () => void;
   className?: string;
 }
 export default function AccordionChevron({
   isExpanded,
+  isWarning,
   setOpen,
   className,
 }: AccordionChevronProps) {
@@ -28,6 +30,7 @@ export default function AccordionChevron({
           "&:hover": {
             cursor: "pointer",
           },
+          stroke: isWarning ? "#C53030" : "black",
         }),
         className
       )}

--- a/src/components/recommandations/RecoReport.tsx
+++ b/src/components/recommandations/RecoReport.tsx
@@ -1,6 +1,15 @@
-import { Box, Divider, Flex, Text } from "@chakra-ui/react";
+import {
+  Accordion,
+  AccordionButton,
+  AccordionItem,
+  AccordionPanel,
+  Box,
+  Divider,
+  Flex,
+  Text,
+} from "@chakra-ui/react";
 import { css } from "@emotion/css";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import {
   useAppSelector,
@@ -56,6 +65,10 @@ export function ReportBody({
   const projectGeneralParams = useAppSelector((state) => state.project.params);
   const recos = useAppSelector((state) => state.recommandations);
   const uncompleteZones = useAppSelector(getUncompleteZones);
+  const [errorPanelToggled, setErrorPanelToggled] = React.useState(false);
+  const toggleErrorPannel = (): void => {
+    setErrorPanelToggled(!errorPanelToggled);
+  };
   useEffect(() => {
     dispatch(
       recommandationsPopulated([...genericRecomandations, ...recommandations])
@@ -64,36 +77,45 @@ export function ReportBody({
 
   return (
     <>
-      <Flex direction="column">
-        {!isReportPage && uncompleteZones.length !== 0 && (
-          <RecoWarning uncompleteZoneNames={uncompleteZones} />
-        )}
-        <ReportGeneralInfo />
-        <Divider />
-        <Box p={2}>
-          <Text fontSize="xs">
-            Estimated visit/month : {projectGeneralParams.nbVisit}
-          </Text>
-        </Box>
-        <ReportToolBar
-          onChangeFilter={(newFilter: FilterType) => setFilterBy(newFilter)}
-          currentFilter={filterBy}
+      <Accordion index={errorPanelToggled ? 0 : 1}>
+        <RecoWarning
+          isHidden={!(!isReportPage && uncompleteZones.length !== 0)}
+          isToggled={errorPanelToggled}
+          uncompleteZoneNames={uncompleteZones}
+          toggleErrorPannel={toggleErrorPannel}
         />
-        <Divider />
-      </Flex>
-      <div className={css({ overflowY: "auto", overflowX: "hidden" })}>
-        {recos?.length > 0 ? (
-          <RecommandationsList
-            recommandations={customRecos || recos}
-            allOpen={!!allOpen}
-            filterBy={filterBy}
-          />
-        ) : (
-          <Flex p={3} color={"gray.400"}>
-            No recommandations. Congrats!
-          </Flex>
-        )}
-      </div>
+        <AccordionItem>
+          <AccordionButton hidden={true} />
+          <AccordionPanel p={0}>
+            <Box>
+              <ReportGeneralInfo />
+            </Box>
+            <Box p={2}>
+              <Text fontSize="xs">
+                Estimated visit/month : {projectGeneralParams.nbVisit}
+              </Text>
+            </Box>
+            <ReportToolBar
+              onChangeFilter={(newFilter: FilterType) => setFilterBy(newFilter)}
+              currentFilter={filterBy}
+            />
+            <Divider />
+            <div className={css({ overflowY: "auto", overflowX: "hidden" })}>
+              {recos?.length > 0 ? (
+                <RecommandationsList
+                  recommandations={customRecos || recos}
+                  allOpen={!!allOpen}
+                  filterBy={filterBy}
+                />
+              ) : (
+                <Flex p={3} color={"gray.400"}>
+                  No recommandations. Congrats!
+                </Flex>
+              )}
+            </div>
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
     </>
   );
 }

--- a/src/components/recommandations/RecoWarning.tsx
+++ b/src/components/recommandations/RecoWarning.tsx
@@ -1,28 +1,111 @@
-import { Flex, Text } from "@chakra-ui/react";
+import {
+  AccordionButton,
+  AccordionItem,
+  AccordionPanel,
+  Box,
+  Center,
+  Flex,
+  Link,
+  Text,
+} from "@chakra-ui/react";
 import { ReactComponent as WarningIcon } from "../../assets/Warning.svg";
 import * as React from "react";
+import AccordionChevron from "../layout/AccordionChevron";
+import { ZoneMissingParams } from "../../app/types/types";
+import { useDispatch } from "react-redux";
+import { zoneActivate } from "../../features/zones/zonesSlice";
 
 interface RecoWarningProps {
-  uncompleteZoneNames: Array<string>;
+  isHidden: boolean;
+  isToggled: boolean;
+  uncompleteZoneNames: Array<ZoneMissingParams>;
+  toggleErrorPannel: () => void;
 }
-export default function RecoWarning({ uncompleteZoneNames }: RecoWarningProps) {
-  /* const zonesParams = useAppSelector((state) => {
-    return Object.values(state.zones).filter((zone) => zone.filter());
-  }); */
+export default function RecoWarning({
+  isHidden,
+  isToggled,
+  uncompleteZoneNames,
+  toggleErrorPannel,
+}: RecoWarningProps) {
+  const dispatch = useDispatch();
+
+  function toggleZone(zoneId: string): void {
+    dispatch(zoneActivate(zoneId));
+  }
+
+  function capitalizeFirstLetter(str: string) {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  }
+
   return (
-    <Flex align={"center"} p={2}>
-      <Text>
-        <WarningIcon></WarningIcon>
-      </Text>
-      <Text fontSize="xs" ml={2} color="red.600">
-        Uncomplete zones are not taken into account in the the
-        calculation:&nbsp;
-        <Text as="b">
-          {uncompleteZoneNames.map((name, index) =>
-            index ? `, ${name}` : name
-          )}
-        </Text>
-      </Text>
-    </Flex>
+    <AccordionItem hidden={isHidden}>
+      <h2>
+        <AccordionButton
+          _hover={{ backgroundColor: "brand.100" }}
+          pl={4}
+          onClick={() => {
+            toggleErrorPannel();
+          }}
+        >
+          <Flex>
+            <Center>
+              <AccordionChevron isWarning={true} isExpanded={isToggled} />
+              <Box>
+                <Text
+                  pl={2}
+                  mr={2}
+                  align="left"
+                  fontSize="xs"
+                  color={"#C53030"}
+                >
+                  You have uncompleted zones that are not taken into account in
+                  the calculation.
+                </Text>
+              </Box>
+              <Box pt={1}>
+                <WarningIcon />
+              </Box>
+            </Center>
+          </Flex>
+        </AccordionButton>
+      </h2>
+      <AccordionPanel pb={4} height={"full"}>
+        {Object.values(uncompleteZoneNames).map((zone) => (
+          <Box p={4} key={zone.zoneId}>
+            <Text fontSize="xs" color={"#C53030"}>
+              <Link
+                onClick={() => {
+                  toggleZone(zone.zoneId);
+                }}
+              >
+                <Text as="u">
+                  <Text as="b">{zone.zoneName}</Text>
+                </Text>
+              </Link>{" "}
+              - {zone.zoneType}
+              {zone.zoneType !== "undefined" && (
+                <Text mt={1}>
+                  Missing parameters:
+                  <br />
+                  {zone.zoneMissingParams.map((param, index) => (
+                    <span key={param}>
+                      {index === 0 ? `${capitalizeFirstLetter(param)}` : ``}
+                      {index !== 0 &&
+                      index !== zone.zoneMissingParams.length - 1
+                        ? `, ${capitalizeFirstLetter(param)}`
+                        : ``}
+                      {zone.zoneMissingParams.length > 1 &&
+                      index === zone.zoneMissingParams.length - 1
+                        ? ` & ${capitalizeFirstLetter(param)}`
+                        : ``}
+                    </span>
+                  ))}
+                </Text>
+              )}
+            </Text>
+          </Box>
+        ))}
+      </AccordionPanel>
+    </AccordionItem>
   );
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -27,3 +27,12 @@ export const isZoneComplete = (zone: Zone) => {
     return false;
   }
 };
+
+export const getMissingZoneParams = (zone: Zone): string[] => {
+  if (zone.params && zone.zoneType) {
+    const zoneTypeEntries = Object.keys(getTypeEntries(zone.zoneType));
+    const zoneEntriesInParams = Object.keys(zone.params);
+    return zoneTypeEntries.filter(value => !zoneEntriesInParams.includes(value));
+  }
+  return [];
+}


### PR DESCRIPTION
Add:
- Hide general calculation panel when toggling calculation warnings
- Show each zone with missing params or undefined zone types
- Toggle specified zone on click on the zone with warnings
- List all missing parameters if the zone type is specified

Fix #71