### PR TITLE
Styling/forms

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,3 +4,7 @@
     #reportToPrint {overflow: inherit}
     #reportToPrint #exportToolbox { display: none;}
 }
+
+input {
+    accent-color: #E435E4;
+}

--- a/src/components/layout/AccordionCustomTitle.tsx
+++ b/src/components/layout/AccordionCustomTitle.tsx
@@ -6,26 +6,34 @@ import { ReactComponent as ImportedGroupIcon } from "../../assets/ImportedGroup_
 import { ReactComponent as DrawnZoneIcon } from "../../assets/DrawnZones_icon.svg";
 
 const iconStyle = css({
-  margin: '3px',
-})
+  margin: "3px",
+});
 
-interface AccordionCustomTitleProps extends ThemingProps<'Text'>{
+interface AccordionCustomTitleProps extends ThemingProps<"Text"> {
   label: string | React.ReactNode;
   icon?: string;
   className?: string;
   iconClassName?: string;
+  size?: string;
 }
 export default function AccordionCustomTitle({
   icon,
   label,
   className,
   iconClassName,
-  size
+  size,
 }: AccordionCustomTitleProps) {
   return (
-    <Flex align='center' className={className}>
-      {icon && <Icon icon={icon} className={iconClassName} /> }
-      <Box fontSize={size || 'md'} whiteSpace="nowrap">{label}</Box>
+    <Flex px={2} align="center" className={className}>
+      {icon && <Icon icon={icon} className={iconClassName} />}
+      <Box
+        fontSize={!size ? "16px" : size}
+        fontWeight={"bold"}
+        px={1}
+        whiteSpace="nowrap"
+      >
+        {label}
+      </Box>
     </Flex>
   );
 }
@@ -36,13 +44,13 @@ interface IconProps {
 }
 function Icon({ icon, className }: IconProps) {
   switch (icon) {
-    case 'settings':
-      return <SettingsIcon className={cx(iconStyle, className)}/>
-    case 'importedGroup':
-      return <ImportedGroupIcon className={cx(iconStyle, className)}/>
-    case 'drawnZone':
-      return <DrawnZoneIcon className={cx(iconStyle, className)}/>
+    case "settings":
+      return <SettingsIcon className={cx(iconStyle, className)} />;
+    case "importedGroup":
+      return <ImportedGroupIcon className={cx(iconStyle, className)} />;
+    case "drawnZone":
+      return <DrawnZoneIcon className={cx(iconStyle, className)} />;
     default:
-      return <>?</>
+      return <>?</>;
   }
 }

--- a/src/components/layout/AccordionItemTitleCustom.tsx
+++ b/src/components/layout/AccordionItemTitleCustom.tsx
@@ -41,7 +41,7 @@ export default function AccordionItemTitleCustom({
         _hover={{ backgroundColor: hoverBgColor || "brand.100" }}
         p={p}
       >
-        <AccordionChevron isExpanded={isExpanded}/>
+        <AccordionChevron isExpanded={isExpanded} />
         {label}
       </AccordionButton>
       <div className={cx("visibleOnHover ", css({ visibility: "hidden" }))}>

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -69,7 +69,7 @@ function PanelTitle({
         minH="50px"
       >
         <>
-          <Heading size={titleSize || "sm"}>{title}</Heading>
+          <Heading size={"16px"}>{title}</Heading>
           {spinner}
         </>
         {toolbarButton}

--- a/src/components/project/GeneralForm.tsx
+++ b/src/components/project/GeneralForm.tsx
@@ -1,6 +1,7 @@
 import {
   AccordionItem,
   AccordionPanel,
+  Box,
   Button,
   Flex,
   Heading,
@@ -85,15 +86,30 @@ export default function GeneralFormAccordion() {
   );
 }
 
+/* <Radio
+                          colorScheme={"brand"}
+                          key={index}
+                          value={data}
+                          onChange={() => {
+                            const newParams = {
+                              params: { ...project.params, [key]: data },
+                            };
+                            dispatch(projectUpdated(newParams));
+                          }}
+                          size="sm"
+                        >
+                          {data}
+                        </Radio> */
+
 function GeneralForm({ project }: { project: Project }) {
   const dispatch = useDispatch();
   return (
     <Flex>
-      <div>
+      <Box px={"4"} mt={"-2"}>
         {Object.entries(GeneralFormEntries).map(([key, data]) => {
           return (
             <div key={key}>
-              <Heading size="sm" my={2}>
+              <Heading fontWeight={"bold"} fontSize={12} mt={2} mb={1}>
                 {getGeneralEntryLabel(key)}
               </Heading>
               {typeof data === "number" && (
@@ -116,40 +132,37 @@ function GeneralForm({ project }: { project: Project }) {
                   disableEdition={project.status === "SIMULATION"}
                 />
               )}
-              <RadioGroup
-                value={
-                  project.params
-                    ? String(project.params[key as keyof GenericParameters])
-                    : undefined
-                }
-                isDisabled={project.status === "SIMULATION"}
-              >
-                <Stack>
-                  {typeof data !== "number" &&
-                    Object.values(data)
-                      .filter((v) => typeof v !== "number")
-                      .map((data, index) => (
-                        <Radio
-                          colorScheme={"brand"}
-                          key={index}
-                          value={data}
+              {typeof data !== "number" &&
+                Object.values(data)
+                  .filter((v) => typeof v !== "number")
+                  .map((data, index) => {
+                    return (
+                      <Flex key={index} gap={1} fontSize={12}>
+                        <input
+                          type="radio"
+                          id={`${key}_${data}`}
+                          checked={
+                            project.params &&
+                            project.params[key as keyof GenericParameters] ===
+                              data
+                          }
                           onChange={() => {
                             const newParams = {
                               params: { ...project.params, [key]: data },
                             };
                             dispatch(projectUpdated(newParams));
                           }}
-                          size="sm"
-                        >
-                          {data}
-                        </Radio>
-                      ))}
-                </Stack>
-              </RadioGroup>
+                        />
+                        <label htmlFor={`${key}_${data}`}>
+                          {data as string}
+                        </label>
+                      </Flex>
+                    );
+                  })}
             </div>
           );
         })}
-      </div>
+      </Box>
     </Flex>
   );
 }

--- a/src/components/recommandations/RecommandationsByZone.tsx
+++ b/src/components/recommandations/RecommandationsByZone.tsx
@@ -72,7 +72,9 @@ export default function RecommandationsByZone({
           <AccordionChevron isExpanded={isOpenAccordion} />
           <GridItem textAlign="start">
             <Text mr={1} fontSize="xs" fontWeight={700}>
-              {zoneRecommandations[0].zoneName}
+              {zoneRecommandations[0].zoneName === "Generic"
+                ? "General Parameters"
+                : zoneRecommandations[0].zoneName}
             </Text>
             <Text fontSize={"xs"}>{zone?.zoneType ?? "–"}</Text>
             {zone?.zoneType ? (

--- a/src/components/zones/MainGroupList.tsx
+++ b/src/components/zones/MainGroupList.tsx
@@ -42,7 +42,7 @@ export default function MainGroupList() {
 
   return (
     <Accordion allowToggle defaultIndex={[0]}>
-      <AccordionItem isDisabled={false}>
+      <AccordionItem isDisabled={false} borderBottom={"none"}>
         {({ isExpanded }) => (
           <>
             {/*         <AccordionButton _hover={{ backgroundColor: "brand.100" }} pl={2}> */}
@@ -269,11 +269,11 @@ const AccordionZones = ({
                   />
                   {!isNewImportSvg() && (
                     <AccordionPanel p={0} bg={"brand.50"}>
-                      <Box p={2} pl={12}>
-                        <Heading size={"xs"}>Type</Heading>
-                        <Text fontSize={"xs"}>
-                          Specific settings on the page
-                        </Text>
+                      <Box fontSize={12} pl={14}>
+                        <Heading size="xs" fontSize="12px">
+                          Type
+                        </Heading>
+                        <Text>Specific settings on the page</Text>
                       </Box>
                       <ZoneParams zone={z} />
                     </AccordionPanel>

--- a/src/components/zones/ZoneListButton.tsx
+++ b/src/components/zones/ZoneListButton.tsx
@@ -146,14 +146,16 @@ export function ZoneListButton({
                 )}
               </>
             }
+            size={"14"}
             icon={"drawnZone"}
             iconClassName={css({ transform: "scale(0.8)" })}
           />
           <Text fontSize={"sm"} color={"gray"} whiteSpace="nowrap" ml={2}>
             {zone.zoneType
-              ? Object.entries(ZoneType).find(
-                  (s) => s[0] === zone.zoneType
-                )?.[1]
+              ? Object.entries(ZoneType)
+                  .find((s) => s[0] === zone.zoneType)?.[1]
+                  .replace(/[A-Z]/g, " $&")
+                  .trim()
               : fallbackTypeZoneDisplayed}
           </Text>
           {zone.zoneType && (

--- a/src/components/zones/ZoneParams.tsx
+++ b/src/components/zones/ZoneParams.tsx
@@ -3,6 +3,7 @@ import {
   AccordionButton,
   AccordionItem,
   AccordionPanel,
+  Text,
   Flex,
 } from "@chakra-ui/react";
 import { Zone, ZoneFigma, ZoneType } from "../../app/types/types";
@@ -29,7 +30,11 @@ export default function ZoneParams({ zone }: ZoneParamsProps) {
                     <AccordionButton pl={12} pr={2} w={"auto"}>
                       <AccordionChevron isExpanded={isExpanded} />
                     </AccordionButton>
-                    <div>{ZoneType[z]}</div>
+                    <div>
+                      <Text fontSize={14}>
+                        {ZoneType[z].replace(/[A-Z]/g, " $&").trim()}
+                      </Text>
+                    </div>
                   </Flex>
                   <AccordionPanel>
                     <ZoneParamsForm zoneId={zone.id} zoneType={z as ZoneType} />

--- a/src/components/zones/zones_settings/ZoneSettingsForm.tsx
+++ b/src/components/zones/zones_settings/ZoneSettingsForm.tsx
@@ -103,7 +103,7 @@ function ZoneSettingsForm({
       }
     }, [pendingKey, pendingValue]);
     return (
-      <Flex direction={"column"} pl={14}>
+      <Flex direction={"column"} pl={14} mt={-1} mb={-3}>
         <CustomModal
           texts={confirmText.changeZoneType}
           isOpen={isOpen}
@@ -127,7 +127,13 @@ function ZoneSettingsForm({
             return (
               <div key={key}>
                 {showHeaders ? (
-                  <Heading size="sm" mt={3} mb={1} textTransform="capitalize">
+                  <Heading
+                    size="sm"
+                    fontSize={12}
+                    mt={2}
+                    mb={1}
+                    textTransform="capitalize"
+                  >
                     {key}
                   </Heading>
                 ) : (
@@ -135,7 +141,7 @@ function ZoneSettingsForm({
                 )}
                 <form>
                   {typeof value === "number" ? (
-                    <Flex gap={10} fontSize={"sm"}>
+                    <Flex gap={10} fontSize={"12px"}>
                       <NumberInput
                         size="sm"
                         id={`${zone.id} ${key}`}
@@ -162,7 +168,7 @@ function ZoneSettingsForm({
                     .map((data, index) => {
                       const inputId = `${zone.id} ${key} ${data}`;
                       return (
-                        <Flex key={index} gap={1} fontSize={"sm"}>
+                        <Flex key={index} gap={1} fontSize={"12px"}>
                           <input
                             type="radio"
                             name={data as string}


### PR DESCRIPTION
Styling update for zone params

Add:
- Change zone params fontSize to match the Figma template
- Change DynamicContent label to Dynamic content
- Change Chakra Radio inputs to default radio inputs
- Set default input accent color as purple
- Rename "Generic" recommendations to "General parameters" (Fix #74)