### PR TITLE
Fix/issue 121/Avoid zone param choice to be blocked

### DIFF
--- a/src/components/zones/zones_settings/ZoneSettingsForm.tsx
+++ b/src/components/zones/zones_settings/ZoneSettingsForm.tsx
@@ -95,6 +95,13 @@ function ZoneSettingsForm({
       };
       dispatch(zoneUpdated(newZone));
     };
+
+    // Reset pending key and value when zone type changes (to avoid blocking the form if the user come back to the same type)
+    useEffect(() => {
+      setPendingKey("");
+      setPendingValue("");
+    }, [zone.zoneType]);
+
     useEffect(() => {
       if (pendingKey !== "") {
         if (zone.zoneType !== formZoneType && zone.zoneType !== undefined) {


### PR DESCRIPTION
Fix #121

Avoid zone param choice to be blocked by previous param choice when coming back to the previous zone type form.